### PR TITLE
Change scramble() to specify arbitrary total

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,9 +64,14 @@ module.exports = function(){
 			return state.join("");
 		},
 		// Scramble the cube
-		scramble: function (total = 25) {
-			var count = 0, state, prevState = cube.states[cube.states.length - 1],
+		scramble: function (reqScrambleLen) {
+			var count = 0, total = 25, state, prevState = cube.states[cube.states.length - 1],
 			move, moves = [], modifiers = ["", "'", "2"];
+			if (reqScrambleLen !== undefined 
+			    && type reqScrambleLen === "number" 
+			    && reqScrambleLen > 0) {
+				total = reqScrambleLen;
+			}
 			while (count < total) {
 				// Generate a random move
 				move = cube.faces[Math.floor(Math.random() * 6)] + modifiers[Math.floor(Math.random() * 3)];

--- a/index.js
+++ b/index.js
@@ -64,8 +64,8 @@ module.exports = function(){
 			return state.join("");
 		},
 		// Scramble the cube
-		scramble: function () {
-			var count = 0, total = 25, state, prevState = cube.states[cube.states.length - 1],
+		scramble: function (total = 25) {
+			var count = 0, state, prevState = cube.states[cube.states.length - 1],
 			move, moves = [], modifiers = ["", "'", "2"];
 			while (count < total) {
 				// Generate a random move


### PR DESCRIPTION
## Change

`cubeScrambler.scramble()` behaves the same before.
`cubeScrambler.scramble(5)` can also work to specify arbitrary total length.

## Example usage

```js
const cubeScrambler = require("cube-scrambler")();

console.log(cubeScrambler.scramble());
// [ 'U2',
//   'D\'',
//   'B\'',
//   'L',
//   'F2',
//   'L2',
//   'R',
// ...
//   'U2',
//   'F',
//   'R2',
//   'D2',
//   'L2' ]

console.log(cubeScrambler.scramble(5));
// [ 'D2', 'R2', 'U', 'F', 'U' ]
```

## Note

I used `scramble: function (total = 25) {` notation to enable it. However, this notation is es2015.

## Reference

* Default parameters - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters
